### PR TITLE
[BUGFIX] Stop POSTs to forum reply pages from being redirected

### DIFF
--- a/bbpress-redirect-single-replies.php
+++ b/bbpress-redirect-single-replies.php
@@ -3,7 +3,7 @@
  * Plugin Name: bbPress - Redirect Single Replies to Topics
  * Description: Redirects single reply pages to the parent topic
  * Author: Pippin Williamson
- * Version: 1.0
+ * Version: 1.1
  */
 
 class BBP_Single_Reply_Redirect {
@@ -13,8 +13,16 @@ class BBP_Single_Reply_Redirect {
 	}
 
 	public function template_redirect() {
-		if( bbp_is_single_reply() && ! bbp_is_reply_edit() ) {
-			wp_redirect( bbp_get_reply_url() ); exit;
+		if( bbp_is_single_reply() ) {
+			/*
+			 * Possibilities:
+			 *   1) is a GET request to reply EDIT page => don't redirect
+			 *   2) is a POST request to reply page, indicating an edit is being posted => don't redirect
+			 *   3) is a GET request to reply page => REDIRECT
+			 */			
+			if( ! bbp_is_reply_edit() && $_SERVER[ 'REQUEST_METHOD' ] !== 'POST' ) {
+				wp_redirect( bbp_get_reply_url() ); exit;
+			}
 		}
 	}
 }


### PR DESCRIPTION
bbPress's edit reply form posts to an action URL that can look like this:

http://www.example.com/reply/[id]/

However, this plugin was intercepting POST requests made to that URL and
redirecting them. This meant that when you click submit on the edit reply form,
you were returned to the parent topic but your edits were not persisted.

Fix this by only redirecting if they are requests to _view_ single replies, _not_ if they are:

* for the edit page OR
* edit form submissions